### PR TITLE
Fix Modrinth update checking for Minecraft 1.0.0 and below

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/UpdateCheckerUtil.java
@@ -11,7 +11,6 @@ import com.terraformersmc.modmenu.api.UpdateInfo;
 import com.terraformersmc.modmenu.config.ModMenuConfig;
 import com.terraformersmc.modmenu.util.mod.Mod;
 import com.terraformersmc.modmenu.util.mod.ModrinthUpdateInfo;
-import net.fabricmc.loader.api.FabricLoader;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -211,8 +210,7 @@ public class UpdateCheckerUtil {
 	}
 
 	private static @Nullable Map<String, VersionUpdate> getUpdatedVersions(Collection<String> modHashes) {
-		String mcVer = FabricLoader.getInstance().getModContainer("minecraft").get()
-		.getMetadata().getVersion().getFriendlyString();
+		String mcVer = VersionUtil.getModrinthCompatibleMcVersion();
 		List<String> loaders = ModMenu.runningQuilt ? Arrays.asList("fabric", "quilt") : Arrays.asList("fabric");
 
 		List<UpdateChannel> updateChannels;

--- a/src/main/java/com/terraformersmc/modmenu/util/VersionUtil.java
+++ b/src/main/java/com/terraformersmc/modmenu/util/VersionUtil.java
@@ -1,5 +1,7 @@
 package com.terraformersmc.modmenu.util;
 
+import net.fabricmc.loader.api.FabricLoader;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -26,5 +28,25 @@ public final class VersionUtil {
 
 	public static String removeBuildMetadata(String version) {
 		return version.split("\\+")[0];
+	}
+
+	/**
+	 * @return a Modrinth API-compatible Minecraft version string.
+	 */
+	public static String getModrinthCompatibleMcVersion() {
+		String version = FabricLoader.getInstance().getModContainer("minecraft").get()
+			.getMetadata().getVersion().getFriendlyString();
+
+		if (version.startsWith("1.0.0-alpha.")) {
+			// Turn 1.0.0-alpha.2.3 into a1.2.3
+			return "a1." + version.substring(12);
+		} else if (version.startsWith("1.0.0-beta.")) {
+			// Turn 1.0.0-beta.7.3 into b1.7.3
+			return "b1." + version.substring(11);
+		} else if (version.equals("1.0.0")) {
+			return "1.0"; // 1.0.0 is the only release with an extra following zero for some reason ...
+		}
+
+		return version;
 	}
 }


### PR DESCRIPTION
Resolves #17. Can be applied to the b1.7 and b1.8 branches w/o conflicts.

The Modrinth API uses different names for these versions than Loader, so they have to be converted:
`1.0.0` -> `1.0`
`1.0.0-beta.7.3` -> `b1.7.3`

