### PR TITLE
Fix crash when search yields no results

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/EntryListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/entries/EntryListWidget.java
@@ -159,7 +159,7 @@ public abstract class EntryListWidget extends ListWidget implements ListWidgetHe
 		bufferBuilder.vertex(this.minX, this.maxY - n3, 0.0, 0.0, 0.0);
 		bufferBuilder.end();
 		n2 = this.getMaxScroll();
-		if (n2 > 0) {
+		if (n2 > 0 && this.getHeight() > 0) {
 			int n11;
 			n = (this.maxY - this.minY) * (this.maxY - this.minY) / this.getHeight();
 			if (n < 32) {


### PR DESCRIPTION
Resolves #20 for Minecraft 1.6 and below.
This results in the same visual as modern ModMenu when no results are present.