### PR TITLE
Fix crash when search yields no results

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ archives_base_name = modmenu
 # Dependencies
 minecraft_version = 1.12.2
 feather_build = 19
-fabric_loader_version = 0.14.22
+fabric_loader_version = 0.16.10
 quilt_loader_version = 0.19.2
 osl_version = 0.10.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ archives_base_name = modmenu
 # Dependencies
 minecraft_version = 1.12.2
 feather_build = 19
-fabric_loader_version = 0.16.10
+fabric_loader_version = 0.15.0
 quilt_loader_version = 0.19.2
 osl_version = 0.10.3

--- a/src/main/java/com/terraformersmc/modmenu/mixin/ListWidgetMixin.java
+++ b/src/main/java/com/terraformersmc/modmenu/mixin/ListWidgetMixin.java
@@ -1,0 +1,23 @@
+package com.terraformersmc.modmenu.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.gui.widget.ListWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ListWidget.class)
+public abstract class ListWidgetMixin {
+	@Shadow
+	protected abstract int getHeight();
+
+	@WrapOperation(method = "render(IIF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ListWidget;getMaxScroll()I"))
+	private int skipBlock(ListWidget instance, Operation<Integer> operation) {
+		if (this.getHeight() == 0) {
+			return 0;
+		} else {
+			return operation.call(instance);
+		}
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
   },
   "depends": {
     "minecraft": "1.12.x",
-    "fabricloader": ">=0.14.21",
+    "fabricloader": ">=0.16.10",
     "osl-entrypoints": ">=0.4.0",
     "osl-resource-loader": ">=0.2.3"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
   },
   "depends": {
     "minecraft": "1.12.x",
-    "fabricloader": ">=0.16.10",
+    "fabricloader": ">=0.15.0",
     "osl-entrypoints": ">=0.4.0",
     "osl-resource-loader": ">=0.2.3"
   },

--- a/src/main/resources/mixins.modmenu.json
+++ b/src/main/resources/mixins.modmenu.json
@@ -6,6 +6,7 @@
   "client": [
     "AccessorButtonWidget",
     "InvokerScreen",
+    "ListWidgetMixin",
     "MixinGameMenu",
     "MixinTitleScreen"
   ],


### PR DESCRIPTION
Resolves #20 for Minecraft 1.7 and above.
This is the same as #21 except applied in the least invasive way to the vanilla class that was used here.