### PR TITLE
Fix erratic and ignored scrolling

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/ModsScreen.java
@@ -283,7 +283,9 @@ public class ModsScreen extends Screen implements Controller {
 	@Override
 	public void keyPressed(char chr, int key) {
 		this.searchBox.keyPressed(chr, key);
-		this.modList.reloadFilters();
+		// Prevent mod list scrolling down when pressing alt
+		// Handling keyboard input is done by the TextFieldWidget Mixin
+		// this.modList.reloadFilters();
 		super.keyPressed(chr, key);
 	}
 

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -91,7 +91,8 @@ public class DescriptionListWidget extends EntryListWidget {
 		if (selectedEntry != lastSelected) {
 			lastSelected = selectedEntry;
 			clear();
-			scroll(-Integer.MAX_VALUE);
+			// Prevent text jumping around
+			// scroll(-Integer.MAX_VALUE);
 			if (lastSelected != null) {
 				DescriptionEntry emptyEntry = new DescriptionEntry("");
 				int wrapWidth = getRowWidth() - 5;

--- a/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
+++ b/src/main/java/com/terraformersmc/modmenu/gui/widget/DescriptionListWidget.java
@@ -342,18 +342,16 @@ public class DescriptionListWidget extends EntryListWidget {
 					this.mouseYStart = mouseY;
 				}
 			} else {
-				while (/*!this.minecraft.options.touchscreen &&*/ Mouse.next()) {
-					int dwheel = Mouse.getEventDWheel();
-					if (dwheel != 0) {
-						if (dwheel > 0) {
-							dwheel = -1;
-						} else if (dwheel < 0) {
-							dwheel = 1;
-						}
-						this.scrollAmount += dwheel * this.entryHeight / 2;
+				int dwheel = Mouse.getEventDWheel();
+				if (dwheel != 0) {
+					if (dwheel > 0) {
+						dwheel = -1;
+					} else {
+						dwheel = 1;
 					}
-					this.minecraft.screen.handleMouse();
+					this.scrollAmount += dwheel * this.entryHeight;
 				}
+
 				this.mouseYStart = -1.0f;
 			}
 		}


### PR DESCRIPTION
Resolves #3.

Fixes mod list scrolling down when pressing alt
Fixes text in description widget jumping when screen receives keyboard input
Fixes scroll position in description widget resetting whenever filters are updated
Fixes most scroll events meant for the description widget being ignored, resulting in slow scrolling

I've also changed the scroll speed in the description to one line per event, as I do not think it's useful to scroll half a line at a time.