### PR TITLE
Fix mods count not displaying in title screen

### DIFF
--- a/src/main/java/com/terraformersmc/modmenu/mixin/MixinTitleScreen.java
+++ b/src/main/java/com/terraformersmc/modmenu/mixin/MixinTitleScreen.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(TitleScreen.class)
+@Mixin(value = TitleScreen.class, priority = 1001)
 public abstract class MixinTitleScreen extends Screen {
 	/** button id for menu.mods button */
 	private static final int TEXTURE_PACKS = 3;
@@ -85,7 +85,7 @@ public abstract class MixinTitleScreen extends Screen {
 			if (ModMenuConfig.EASTER_EGGS.getValue() && TranslationUtil.hasTranslation(specificKey + ".secret")) {
 				replacementKey = specificKey + ".secret";
 			}
-			return string.replace(I18n.translate(I18n.translate("menu.modded")), I18n.translate(replacementKey, count));
+			return string + I18n.translate(replacementKey, count);
 		}
 		return string;
 	}


### PR DESCRIPTION
I noticed this was a problem in Beta 1.7, so I decided to try fixing it. It wasn't too hard besides needing to change the mixin priority so it shows after the mod loader!

Before:
![Screenshot_20250321_210813](https://github.com/user-attachments/assets/5b1a7815-866a-430c-be48-d791145625ce)

After:
![Screenshot_20250321_210855](https://github.com/user-attachments/assets/cbd3eed7-a5bd-4133-8d71-7057fa2ba730)
